### PR TITLE
Fixed session/cookie persistence in iOS14

### DIFF
--- a/src/Everwealth.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
+++ b/src/Everwealth.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
@@ -1,8 +1,8 @@
-﻿using AuthenticationServices;
+﻿using System.Threading;
+using System.Threading.Tasks;
+using AuthenticationServices;
 using Foundation;
 using IdentityModel.OidcClient.Browser;
-using System.Threading;
-using System.Threading.Tasks;
 using UIKit;
 
 namespace Everwealth.OidcClient
@@ -12,13 +12,44 @@ namespace Everwealth.OidcClient
     /// </summary>
     public class ASWebAuthenticationSessionBrowser : IOSBrowserBase
     {
+        /// <summary>
+        /// Configuration for the ASWebAuthenticationSession.
+        /// </summary>
+        public ASWebAuthenticationSessionOptions SessionOptions { get; }
+
+        /// <summary>
+        /// Creates a new instance of the ASWebAuthenticationSession Browser.
+        /// </summary>
+        /// <param name="sessionOptions">The <see cref="ASWebAuthenticationSessionOptions"/> specifying the configuration for the ASWebAuthenticationSession.</param>
+        /// <example>
+        /// If any custom browser configuration is needed (e.g. using <see cref="ASWebAuthenticationSessionOptions.PrefersEphemeralWebBrowserSession"/>), 
+        /// a new browser instance should be instantiated and passed to <see cref="Auth0ClientOptions.Browser"/>.
+        /// <code>
+        /// var client = new AuthClient(new AuthClientOptions
+        /// {
+        ///   Domain = "YOUR_DOMAIN",
+        ///   ClientId = "YOUR_CLIENT_ID",
+        ///   Browser = new ASWebAuthenticationSessionBrowser(
+        ///     new ASWebAuthenticationSessionOptions
+        ///     {
+        ///       PrefersEphemeralWebBrowserSession = true
+        ///     }
+        ///   )
+        /// });
+        /// </code>
+        /// </example>
+        public ASWebAuthenticationSessionBrowser(ASWebAuthenticationSessionOptions sessionOptions = null)
+        {
+            SessionOptions = sessionOptions;
+        }
+
         /// <inheritdoc/>
         protected override Task<BrowserResult> Launch(BrowserOptions options, CancellationToken cancellationToken = default)
         {
-            return Launch(options);
+            return Start(options, SessionOptions);
         }
 
-        internal static Task<BrowserResult> Start(BrowserOptions options)
+        internal static Task<BrowserResult> Start(BrowserOptions options, ASWebAuthenticationSessionOptions sessionOptions = null)
         {
             var tcs = new TaskCompletionSource<BrowserResult>();
 
@@ -32,22 +63,26 @@ namespace Everwealth.OidcClient
                     asWebAuthenticationSession.Dispose();
                 });
 
-            //// iOS 13 requires the PresentationContextProvider set
-            //if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
-            //    asWebAuthenticationSession.PresentationContextProvider = new PresentationContextProviderToSharedKeyWindow();
+            if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+            {
+                // iOS 13 requires the PresentationContextProvider set
+                asWebAuthenticationSession.PresentationContextProvider = new PresentationContextProviderToSharedKeyWindow();
+                // PrefersEphemeralWebBrowserSession is only available on iOS 13 and up.
+                asWebAuthenticationSession.PrefersEphemeralWebBrowserSession = sessionOptions != null ? sessionOptions.PrefersEphemeralWebBrowserSession : false;
+            }
 
             asWebAuthenticationSession.Start();
 
             return tcs.Task;
         }
 
-        //class PresentationContextProviderToSharedKeyWindow : NSObject, IASWebAuthenticationPresentationContextProviding
-        //{
-        //    public UIWindow GetPresentationAnchor(ASWebAuthenticationSession session)
-        //    {
-        //        return UIApplication.SharedApplication.KeyWindow;
-        //    }
-        //}
+        class PresentationContextProviderToSharedKeyWindow : NSObject, IASWebAuthenticationPresentationContextProviding
+        {
+            public UIWindow GetPresentationAnchor(ASWebAuthenticationSession session)
+            {
+                return UIApplication.SharedApplication.KeyWindow;
+            }
+        }
 
         private static BrowserResult CreateBrowserResult(NSUrl callbackUrl, NSError error)
         {

--- a/src/Everwealth.OidcClient.iOS/ASWebAuthenticationSessionOptions.cs
+++ b/src/Everwealth.OidcClient.iOS/ASWebAuthenticationSessionOptions.cs
@@ -1,0 +1,16 @@
+﻿namespace Everwealth.OidcClient
+{
+    /// <summary>
+    /// Specifies options that can be passed to <see cref="ASWebAuthenticationSessionBrowser"/> implementations.
+    /// </summary>
+    public class ASWebAuthenticationSessionOptions
+    {
+        /// <summary>
+        /// Specify whether or not EphemeralWebBrowserSessions should be preferred. Defaults to false.
+        /// </summary>
+        /// <remarks>
+        /// Setting <see cref="PrefersEphemeralWebBrowserSession"/> to true will disable Single Sign On (SSO) on iOS 13+.
+        /// </remarks>
+        public bool PrefersEphemeralWebBrowserSession { get; set; }
+    }
+}

--- a/src/Everwealth.OidcClient.iOS/Everwealth.OidcClient.iOS.csproj
+++ b/src/Everwealth.OidcClient.iOS/Everwealth.OidcClient.iOS.csproj
@@ -51,6 +51,7 @@
     <Compile Include="SFSafariViewControllerBrowser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WKWebViewBrowser.cs" />
+    <Compile Include="ASWebAuthenticatedSessionOptions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Everwealth.OidcClient.Core\Everwealth.OidcClient.Core.csproj">

--- a/src/Everwealth.OidcClient.iOS/WKWebViewBrowser.cs
+++ b/src/Everwealth.OidcClient.iOS/WKWebViewBrowser.cs
@@ -125,6 +125,7 @@ namespace Everwealth.OidcClient
             _options = options;
 
             var webViewConfig = new WKWebViewConfiguration();
+            webViewConfig.WebsiteDataStore = WKWebsiteDataStore.NonPersistentDataStore;
             //webViewConfig.SetUrlSchemeHandler(new CallbackHandler(), endUrl.Scheme);
             WebView = new WKWebView(new CGRect(0, 0, 0, 0), webViewConfig);
 


### PR DESCRIPTION
### Changes

- [x] Updated ASWebAuthenticatedSession to support ephemeral sessions
- [x] Updated WKWebViewBrowser to use a non persisted data store

Both of these things appear to have changed in iOS 14 to better support SSO

### Testing

Test on iOS13 and 14

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not
